### PR TITLE
Fix spacing and page break handling

### DIFF
--- a/cv_generator.py
+++ b/cv_generator.py
@@ -99,8 +99,14 @@ class CVGenerator:
         logger.debug(f"Calculated content density: {content_density:.2f}")
         theme = self._adjust_theme_for_content_density(content_density)
 
-        # Create output directory if it doesn't exist
-        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        # Create output directory if it doesn't exist. When output_path
+        # is just a filename without any directory component, os.path.dirname
+        # returns an empty string which would cause ``os.makedirs`` to raise
+        # ``FileNotFoundError``.  Guard against this by checking the directory
+        # portion before attempting to create it.
+        output_dir = os.path.dirname(os.path.abspath(output_path))
+        if output_dir:
+            os.makedirs(output_dir, exist_ok=True)
         
         # Get layout data from CVData (which includes defaults and user overrides from JSON)
         layout_data_dict = optimized_data.get_layout_data() 

--- a/cv_generator.py
+++ b/cv_generator.py
@@ -104,7 +104,7 @@ class CVGenerator:
         # returns an empty string which would cause ``os.makedirs`` to raise
         # ``FileNotFoundError``.  Guard against this by checking the directory
         # portion before attempting to create it.
-        output_dir = os.path.dirname(os.path.abspath(output_path))
+        output_dir = os.path.dirname(output_path)
         if output_dir:
             os.makedirs(output_dir, exist_ok=True)
         

--- a/templates/base_template.py
+++ b/templates/base_template.py
@@ -145,6 +145,10 @@ class BaseTemplate(ABC):
             self.canvas.setFont(self.theme.body_font, self.theme.body_font_size)
             self.canvas.setFillColor(self.theme.get_color(self.theme.text_color))
 
+        # Save the restored graphics state so that any later ``restoreState``
+        # calls bring us back to this consistent baseline on each page.
+        self.canvas.saveState()
+
     def set_fill_color(self, color_str: str) -> None:
         """
         Set fill color from a hex string or color name.

--- a/templates/base_template.py
+++ b/templates/base_template.py
@@ -136,6 +136,15 @@ class BaseTemplate(ABC):
         # Reset current_y to top of content area on new page
         self.current_y = self.layout.page_size[1] - self.layout.top_margin
 
+        # After calling ``showPage`` ReportLab resets the graphics state which
+        # results in fonts and colors falling back to defaults on the new page.
+        # This caused inconsistent spacing and layout after page breaks.  Ensure
+        # the theme's default font and text color are re-applied so subsequent
+        # drawing commands use the expected settings.
+        if self.theme is not None:
+            self.canvas.setFont(self.theme.body_font, self.theme.body_font_size)
+            self.canvas.setFillColor(self.theme.get_color(self.theme.text_color))
+
     def set_fill_color(self, color_str: str) -> None:
         """
         Set fill color from a hex string or color name.


### PR DESCRIPTION
## Summary
- ensure output directory creation doesn't fail when only a filename is provided
- keep font and color settings after each page break so spacing stays consistent

## Testing
- `python main.py data/cv_data.json output.pdf --template minimal`
- `python main.py data/cv_data.json output_modern.pdf --template modern`
- `python main.py data/cv_data.json output_two.pdf --template two_column`


------
https://chatgpt.com/codex/tasks/task_e_68448423bda883289995ef122e9cb3d2