### PR TITLE
Improve PDF testing with baseline diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,26 @@ TechnicalCVGenerator/
 └── README.md         # This file
 ```
 
+## Testing
+
+Automated tests validate that the PDF generator works correctly. Generated PDF
+files are converted to ASCII using `pdfminer.six` and compared against baseline
+output stored under `tests/expected`. If the ASCII output differs from the
+baseline a unified diff is shown. To run the tests install the dependencies and
+execute `pytest`:
+
+```bash
+pip install -r requirements.txt
+pip install pytest
+pytest
+```
+
+If you intentionally change the PDF output, regenerate the baseline with:
+
+```bash
+python -m tests.generate_baseline
+```
+
 ## Contributing
 
 Contributions are welcome! Some ideas for improvements:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 reportlab>=4.0.0
 pyphen>=0.14.0
 requests>=2.31.0
-Pillow>=10.0.0 
+Pillow>=10.0.0
+pdfminer.six>=20221105

--- a/tests/ascii_utils.py
+++ b/tests/ascii_utils.py
@@ -1,0 +1,31 @@
+from pdfminer.high_level import extract_text
+from typing import Iterable
+import difflib
+
+
+def pdf_to_ascii(pdf_path: str) -> str:
+    """Return an ASCII representation of the PDF for testing."""
+    return extract_text(pdf_path)
+
+
+def diff_ascii(expected: str, actual: str) -> str:
+    """Return a unified diff between two ASCII strings."""
+    return "\n".join(
+        difflib.unified_diff(
+            expected.splitlines(),
+            actual.splitlines(),
+            fromfile="expected",
+            tofile="actual",
+            lineterm="",
+        )
+    )
+
+
+def compare_with_baseline(pdf_path: str, baseline_ascii_path: str) -> None:
+    """Assert that a generated PDF matches the baseline ASCII content."""
+    actual = pdf_to_ascii(pdf_path)
+    with open(baseline_ascii_path, "r") as fh:
+        expected = fh.read()
+    if actual != expected:
+        diff = diff_ascii(expected, actual)
+        raise AssertionError(f"PDF content mismatch:\n{diff}")

--- a/tests/expected/minimal_cv_ascii.txt
+++ b/tests/expected/minimal_cv_ascii.txt
@@ -1,0 +1,115 @@
+John Doe
+
+ Email: john.doe@exa...
+
+ London, United Kingdom
+
+ Phone: +44 123 456 7...
+
+ LinkedIn: linkedin.com/...
+
+PROFILE
+Senior Software Engineer with 7+ years of experience in full-stack development. Passionate about building
+scalable applications and leading technical teams. Expertise in modern web technologies and cloud ar-
+chitecture.
+
+TECHNICAL SKILLS
+Frontend Development:
+
+React, Angular, TypeScript, JavaScript, HTML5, CSS3
+
+Backend Development: Python, Node.js, Java, RESTful APIs, GraphQL
+Databases: PostgreSQL, MongoDB, Redis, MySQL
+Cloud & DevOps: AWS, Docker, Kubernetes, CI/CD, Terraform
+Tools & Practices: Git, Agile/Scrum, TDD, Code Review, JIRA
+
+PROFESSIONAL EXPERIENCE
+Tech Corp Ltd
+
+Senior Software Engineer
+
+(cid:127) Led development team of 5 engineers in building microservices architecture
+
+Implemented CI/CD pipeline reducing deployment time by 60%
+
+(cid:127) Mentored junior developers and conducted code reviews
+
+(cid:127) Architected and developed RESTful APIs serving 1M+ daily requests
+
+StartUp Inc
+
+Full Stack Developer
+
+(cid:127) Developed React-based frontend for e-commerce platform
+
+(cid:127) Built Node.js backend services handling payment processing
+
+Improved application performance by 40% through optimization
+
+(cid:127) Collaborated with UX team to implement responsive designs
+
+Digital Agency
+
+Junior Developer
+
+(cid:127) Developed and maintained client websites using modern frameworks
+
+(cid:127) Participated in agile development process and daily standups
+
+(cid:127) Wrote unit tests achieving 80% code coverage
+
+(cid:127) Assisted in database design and optimization
+
+3 years
+
+2 years
+
+2 years
+
+(cid:127)
+(cid:127)
+John Doe
+
+ Email: john.doe@exa...
+
+ London, United Kingdom
+
+ Phone: +44 123 456 7...
+
+ LinkedIn: linkedin.com/...
+
+EDUCATION
+University of Example
+
+BSc Computer Science
+
+PROJECTS & ACHIEVEMENTS
+Project Management System
+
+2010 - 2014
+
+Designed and implemented a web-based project management tool using React and Node.js. Features in-
+cluded real-time collaboration, task tracking, and reporting dashboards. Successfully deployed to pro-
+duction serving 500+ users.
+
+E-commerce Platform
+
+Built a scalable e-commerce solution with microservices architecture. Implemented features including
+product catalog, shopping cart, payment integration, and order management. Achieved 99.9% uptime in
+production.
+
+Open Source Contribution
+
+Active contributor to popular open-source projects. Submitted PRs for bug fixes and feature en-
+hancements. Maintained personal npm packages with 10k+ weekly downloads.
+
+ADDITIONAL INFORMATION
+(cid:127) Fluent in English and Spanish
+
+(cid:127) Available for remote work and occasional travel
+
+(cid:127) Active speaker at local tech meetups
+
+(cid:127) Certified AWS Solutions Architect
+
+

--- a/tests/generate_baseline.py
+++ b/tests/generate_baseline.py
@@ -1,0 +1,30 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from cv_generator import CVGenerator
+from tests.ascii_utils import pdf_to_ascii
+
+
+def main():
+    data_path = os.path.join(os.path.dirname(__file__), '..', 'cv_data_example.json')
+    output_pdf = os.path.join(os.path.dirname(__file__), 'expected', 'tmp_baseline.pdf')
+
+    generator = CVGenerator()
+    generator.create_cv(
+        data_path=data_path,
+        output_path=output_pdf,
+        template_name='minimal'
+    )
+
+    ascii_text = pdf_to_ascii(output_pdf)
+    expected_path = os.path.join(os.path.dirname(__file__), 'expected', 'minimal_cv_ascii.txt')
+    with open(expected_path, 'w') as fh:
+        fh.write(ascii_text)
+
+    os.remove(output_pdf)
+    print(f'Baseline updated: {expected_path}')
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_pdf_generation.py
+++ b/tests/test_pdf_generation.py
@@ -1,0 +1,24 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from cv_generator import CVGenerator
+from tests.ascii_utils import compare_with_baseline
+
+
+def test_generate_pdf(tmp_path):
+    data_path = os.path.join('cv_data_example.json')
+    output_file = tmp_path / 'test_cv.pdf'
+
+    generator = CVGenerator()
+    generator.create_cv(
+        data_path=data_path,
+        output_path=str(output_file),
+        template_name='minimal'
+    )
+
+    assert output_file.exists()
+    assert output_file.stat().st_size > 0
+
+    baseline = os.path.join('tests', 'expected', 'minimal_cv_ascii.txt')
+    compare_with_baseline(str(output_file), baseline)


### PR DESCRIPTION
## Summary
- compare generated PDFs to stored baseline ASCII output
- include helper for diffing PDFs and generating baseline
- document baseline workflow in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68455b73dd4c8328a68cea10af896148